### PR TITLE
Update Node/Postgres Install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Linter and linter-eslint should be on that list, like in this screen shot:
 
 For both Windows and Linux users, please follow the default installation instructions taking care not to change values such as the default port numbers (You may be prompted to change them, but should also be given default values).
 
-#### Windows
+### Windows
 
 *For reference, these instructions are taken from the following documentation: http://www.postgresqltutorial.com/install-postgresql/*
 
@@ -136,7 +136,7 @@ When you installed PostgreSQL, the installer also installed some extra tools. On
 
 **If you are having issues with the installation, please contact your instructor.**
 
-#### Linux
+### Linux
 
 *For reference, these instructions are taken from the following documentation: https://www.postgresql.org/download/*
 
@@ -154,7 +154,7 @@ When you installed PostgreSQL, the installer also installed some extra tools. On
 
 **If you are having issues with installation, please contact your instructor.**
 
-#### MacOS
+### MacOS
 
 You should have already verified during the Node installation that you have Homebrew installed. Please see that section above for more details if not.
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ If you haven't already, install [Atom](https://atom.io). If you have used an adv
 
 ## Install Node
 
-*Note* If you get an error while installing these packages such as "try again as root/administrator", you may need to use the `sudo` command to get administrator access. For example `sudo apt-get install nodejs`.
+*Note*: If you get an error while installing these packages such as "try again as root/administrator", you may need to use the `sudo` command to get administrator access. For example `sudo apt-get install nodejs`.
 
 #### Linux instructions
 
-  To install Node, open your Terminal, and copy and paste the following line, then hit Enter:
+  To install Node, open your Terminal and copy and paste the following line, then hit Enter:
 
   `sudo apt-get install nodejs`
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ For both Windows and Linux users, please follow the default installation instruc
 
 *For reference, these instructions are taken from the following documentation: http://www.postgresqltutorial.com/install-postgresql/*
 
-**NOTE: If you are running Windows 8 or 10, you need to create a Windows users with administrator role e.g., postgres and use this user to run the installation file.**
+**NOTE: If you are running Windows 8 or 10, you need to create a Windows user with administrator role e.g., postgres and use this user to run the installation file.**
 
 - Your **Default** database super user is: *postgres*
 - You will be asked to enter and confirm a database password.

--- a/README.md
+++ b/README.md
@@ -183,10 +183,10 @@ Now, whenever you first start up your computer, you just have to run `pgstart` t
   - For Mac, run your new `pgstart` alias, then type `psql`
   - For Windows, open up your psql program (SQL Shell)
   - For Linux, run `sudo -u postgres psql`
-1. You should be at a prompt that looks like `postgres=#`
-1. Enter the following command: `CREATE DATABASE kilovolt;`. *Note the semicolon. If you forget it, your prompt will go to a new line and look like* `postgres-#`. *This means you have an unterminated command and the prompt will just keep going to new lines until you enter a semicolon*.
+2. You should be at a prompt that looks like `postgres=#`
+3. Enter the following command: `CREATE DATABASE kilovolt;`. *Note the semicolon. If you forget it, your prompt will go to a new line and look like* `postgres-#`. *This means you have an unterminated command and the prompt will just keep going to new lines until you enter a semicolon*.
   - You should receive the feedback "CREATE DATABASE".
-1. Now enter: `CREATE DATABASE portfolio;`. This should mirror the above step.
-1. Verify that your databases were created by running `\l` (no semicolon). You should see a list of databases, including `kilovolt` and `portfolio`. You should be able to connect to a database by running `\c DATABASE_NAME`, e.g. `\c kilovolt` or `\c portfolio`.
+4. Now enter: `CREATE DATABASE portfolio;`. This should mirror the above step.
+5. Verify that your databases were created by running `\l` (no semicolon). You should see a list of databases, including `kilovolt` and `portfolio`. You should be able to connect to a database by running `\c DATABASE_NAME`, e.g. `\c kilovolt` or `\c portfolio`.
 
 Congrats! You're all done. Well, except for your class-specific directory instructions :wink:

--- a/README.md
+++ b/README.md
@@ -97,15 +97,44 @@ Linter and linter-eslint should be on that list, like in this screen shot:
 ## Install PostgreSQL Database Software
 *Please note that if you have a previously installed version of PostgreSQL on any operating system, you should be aware of any username and password that you've set for that installation. If you're unsure please uninstall and reinstall a fresh copy, which will also install the latest stable version.*
 
+
 For both Windows and Linux users, please follow the default installation instructions taking care not to change values such as the default port numbers (You may be prompted to change them, but should also be given default values).
 
 #### Windows
 
-Follow the download and installation instructions on this page: [Installing Postgresql](http://www.postgresqltutorial.com/install-postgresql)
+*For reference, these instructions are taken from the following documentation: http://www.postgresqltutorial.com/install-postgresql/*
+
+**NOTE: If you are running Windows 8 or 10, you need to create a Windows users with administrator role e.g., postgres and use this user to run the installation file.**
 
 - Your **Default** database super user is: *postgres*
 - You will be asked to enter and confirm a database password.
 - **Be sure you document your default user and password**, as you will need them later in the course. We are working securely on your computer, so a simple password like `1234` will suffice, and there's no need to change the default user.
+
+**There are three steps to complete the PostgreSQL installation**:
+
+1. Download PostgreSQL installer for Windows
+1. Install PostgreSQL
+1. Verify the installation
+
+**Downloading the installer**
+
+- Go to the PostgreSQL [official website](http://www.postgresql.org/download/windows/).
+- Click on the [download installer from EnterpriseDB](https://www.enterprisedb.com/downloads/postgres-postgresql-downloads#windows). Choose the latest version to download. It takes a few minutes to complete the download.
+
+**Installing**
+
+Double click on the installer file. An installation wizard will appear and guide you through multiple steps where you can choose different options that you would like to have in PostgreSQL. For now, just select default values.
+
+**Verify Installation**
+
+When you installed PostgreSQL, the installer also installed some extra tools. One of them is psql (it may be called SQL Shell).
+
+- Launch psql.
+- When it prompts you for input, just hit enter to select default values until it asks for a password. You will put in the password you entered during installation.
+- You should have a window that [looks like this](http://www.postgresqltutorial.com/wp-content/uploads/2012/08/psql.png).
+- In this window, you can enter SQL statements, which must all end with semicolons. Congratulations, you've installed correctly!
+
+**If you are having issues with the installation, please contact your instructor.**
 
 #### Linux
 

--- a/README.md
+++ b/README.md
@@ -138,9 +138,21 @@ When you installed PostgreSQL, the installer also installed some extra tools. On
 
 #### Linux
 
-Follow the download and installation instructions on this page for your Linux distribution: [Installing Postgresql](https://www.postgresql.org/download/)
+*For reference, these instructions are taken from the following documentation: https://www.postgresql.org/download/*
 
 - If asked to provide or set a username and password, **be sure to document the username and password**, as you will need them later in the course.
+- `sudo apt-get install postgresql`
+- You will be prompted with the message that a certain amount of disk space will be used and asked if this is OK. Type `y`, then hit enter.
+- Several commands will automatically run, this may take a few minutes.
+- **You will likely NOT be prompted for a default username or password.** You will need to set one in psql if this is the case.
+
+**Verifying Installation And Setting A Password**
+- You should be able to run the command `sudo -u postgres psql`. You will be asked for your administrator password - this is what you usually enter when you run `sudo` commands. This will log you into the psql prompt as the user postgres.
+- You should now have a prompt that looks like `postgres=#`. You can run SQL commands from here, which must end in semicolons.
+- If you were not prompted for a default user or password, we will set one using psql. If you type `\du`, you can get a list of users associated with PostgreSQL. You should see a single user, `postgres`. In order to give this user a password, enter the following command: `ALTER ROLE postgres PASSWORD 'your-password-here';`, replacing "your-password-here" with whatever you want it to be. Remember that your password must be wrapped in quotes. *Don't forget the semicolon*.
+- If successful, you will receive the feedback `ALTER ROLE`.
+
+**If you are having issues with installation, please contact your instructor.**
 
 #### MacOS
 
@@ -151,18 +163,30 @@ To install PostgreSQL, open your Terminal, and enter:
 
 This will create a user for you, that matches your logged in user account. Run the `whoami` command in the terminal if you aren't sure what that is. This user has a blank password set as the default.
 
+*You will need to run this command whenever you first start your computer and open up the terminal in order to start your Postgres server:*
+
+`pgstart='pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start'`
+
+Since that's rather verbose, we can set it as an alias!
+
+`alias pgstart='pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start'`
+
+However, aliases are temporary. You would need to set that alias each time you opened up a new terminal window. Instead, we can tell our system to always set that alias whenever a terminal is opened. Find your **.bashrc** or **.bash_profile** file - it will probably be in your home (~) directory. Run `atom .bashrc` or `atom .bash_profile` to open it up, then on a new line, paste this in:
+
+`alias pgstart='pg_ctl -D /usr/local/var/postgres/ -l /usr/local/var/postgres/server.log start'`
+
+Now, whenever you first start up your computer, you just have to run `pgstart` to get your Postgres server running.
+
 ### Startup and Create some databases
 
-Read the output of the above installation instructions carefully. It should tell you what you need to do, in order to start Postgres. There might be 2 different options (one to start it automatically, one to start it manually). Pick one, and run the command. Once again, read the output of the command. If postgres is running correctly, the `psql` command should run without error and put you into a `pg>` prompt.
-
-Now that Postgres is running, you should be able to create some databases to use in the class. From a command prompt, run these commands, utilizing the username and password form your set up. :
-
-```
-createdb -U USERNAME kilovolt
-createdb -U USERNAME portfolio
-```
-
-These commands should run without an error (or any feedback really). If a message does print, read it carefully and use the info to troubleshoot.  
-----
+1. Login to psql.
+  - For Mac, run your new `pgstart` alias, then type `psql`
+  - For Windows, open up your psql program (SQL Shell)
+  - For Linux, run `sudo -u postgres psql`
+1. You should be at a prompt that looks like `postgres=#`
+1. Enter the following command: `CREATE DATABASE kilovolt;`. *Note the semicolon. If you forget it, your prompt will go to a new line and look like* `postgres-#`. *This means you have an unterminated command and the prompt will just keep going to new lines until you enter a semicolon*.
+  - You should receive the feedback "CREATE DATABASE".
+1. Now enter: `CREATE DATABASE portfolio;`. This should mirror the above step.
+1. Verify that your databases were created by running `\l` (no semicolon). You should see a list of databases, including `kilovolt` and `portfolio`. You should be able to connect to a database by running `\c DATABASE_NAME`, e.g. `\c kilovolt` or `\c portfolio`.
 
 Congrats! You're all done. Well, except for your class-specific directory instructions :wink:

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ However, aliases are temporary. You would need to set that alias each time you o
 
 Now, whenever you first start up your computer, you just have to run `pgstart` to get your Postgres server running.
 
-### Startup and Create some databases
+## ALL USERS: Startup and Create some databases
 
 1. Login to psql.
   - For Mac, run your new `pgstart` alias, then type `psql`

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Now let's verify that it is installed. Enter the following into your terminal:
 
 `node -e 'console.log("works")'`
 
-You should get a response that says "works". If not, try reinstalling Node again
+You should get a response that says "works". If not, try reinstalling Node again. If you are still having issues, please contact your instructor.
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Linter and linter-eslint should be on that list, like in this screen shot:
  ----
 
 ## Install PostgreSQL Database Software
-*Please note that if you have a previously installed version of PostgreSQL on any operating system, you should be aware of any username and password that you've set for that installation. If you're unsure please uninstall and reinstall a fresh copy, which will also install the latest stable version.*
+*Please note that if you have a previously installed version of PostgreSQL on any operating system, you should be aware of any username and password that you've set for that installation. If you're unsure please uninstall and reinstall a fresh copy, which will also install the latest stable version. Additionally, if you are using a version before 9.5, you should uninstall and reinstall. You will be unable to complete certain labs if you are using version 9.4 or previous!*
 
 
 For both Windows and Linux users, please follow the default installation instructions taking care not to change values such as the default port numbers (You may be prompted to change them, but should also be given default values).

--- a/README.md
+++ b/README.md
@@ -20,17 +20,11 @@ If you haven't already, install [Atom](https://atom.io). If you have used an adv
 
   `sudo apt-get install nodejs`
 
-  If this did not work, try the following:
+  Afterwards, you'll want to install Node Package Manager (NPM).
 
-  `curl -sL https://deb.nodesource.com/setup_5.x | sudo -E bash -`
+  `sudo apt-get install npm`
 
-  It will churn away for a while, and then once it's done you can run the following command:
-
-  `sudo apt-get install nodejs`
-
-  If, once again, you did not achieve success, try [these instructions to build from source](https://gist.github.com/toastynerd/d3e563522977f6750c32).
-
-  Finally, `sudo apt-get install npm`
+  If you run into issues trying to install Node from these steps, please contact your instructor.
 
 #### Mac instructions
 
@@ -130,7 +124,7 @@ This will create a user for you, that matches your logged in user account. Run t
 
 ### Startup and Create some databases
 
-Read the output of the above installation instructions carefully. It should tell you what you need to do, in order to start Postgres. There might be 2 different options (one to start it automatically, one to start it manually). Pick one, and run the command. Once again, read the output of the command. If postgres is running correctly, the `psql` command should run without error and put you into a `pg>` prompt. 
+Read the output of the above installation instructions carefully. It should tell you what you need to do, in order to start Postgres. There might be 2 different options (one to start it automatically, one to start it manually). Pick one, and run the command. Once again, read the output of the command. If postgres is running correctly, the `psql` command should run without error and put you into a `pg>` prompt.
 
 Now that Postgres is running, you should be able to create some databases to use in the class. From a command prompt, run these commands, utilizing the username and password form your set up. :
 


### PR DESCRIPTION
There were a number of issues with users having trouble installing Postgres, or installing outdated versions of either Node or Postgres as a result of following certain chains of links in the README. This PR is designed to alleviate those issues for future courses.

After discussing with Sam, the Node install instructions were simplified to the single install commands, with the addition that, if for some reason those don't work, to contact your instructor. Sam felt that having several, "If that didn't work, do this, if that didn't work do this" steps would lead students to skipping to the end and not properly following instructions. In our cohort's particular case, this led to installing Node from source using Tyler's instructions - which specified version 4, causing an error during project week.

I took all the install directions from the previous link to Windows Installation and migrated them into our README. Several students weren't sure they had installed correctly, as they were unable to just type psql in their terminal - it turns out, for Windows, the installation process gives another program called SQL Shell that they have to use. I've added in additional instructions to open that and how to interact with it to the best of my knowledge.

I also uninstalled my Postgres and reinstalled it, documenting my process along the way. By default, the Linux installation does not prompt the user for a default username or password (and as a result, sets the password to nothing). I added in additional instructions to properly set the password using psql, since this is something we had to do with all the Linux students, anyway.

Linux also has a Postgres prompt and a psql prompt - I've changed the instructions to simply log the users directly into the psql prompt as the default postgres user to try and simplify and streamline the process.

Mac users have a rather long, complex-looking line of code that must be run to start their Postgres servers whenever they first start their computer. Sam has this mapped to an alias, so I included instructions on how to include that alias in their .bashrc or .bash_profile files, so that they can simply follow along with Sam.

For creating databases, I changed the instructions to simply have the students log into psql however they need to, depending on their OS, then do it using SQL commands. This should ensure everyone is on the same page and will get some very simple introduction to interacting with the psql prompt/shell.

As a final note, I left links to the previous installation docs in case they are still needed, but are simply mentioned with the line, "For reference, these steps are taken from the following docs."