### PR TITLE
Added extra information for Mac users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,13 @@ However, aliases are temporary. You would need to set that alias each time you o
 
 Now, whenever you first start up your computer, you just have to run `pgstart` to get your Postgres server running.
 
+If, for some reason, the `pgstart` command is not available when you open a new window, you should be able to run `source .bashrc` or `source .bash_profile` (wherever you put the alias), then `pgstart` should be available.
+
 ## ALL USERS: Startup and Create some databases
 
 1. Login to psql.
-  - For Mac, run your new `pgstart` alias, then type `psql`
+  - For Mac, run your new `pgstart` alias, then type `psql`.
+    - If the response is, "Can't find database *yourUserName*", run `createdb -U yourUserName`, then run `psql` again.
   - For Windows, open up your psql program (SQL Shell)
   - For Linux, run `sudo -u postgres psql`
 2. You should be at a prompt that looks like `postgres=#`


### PR DESCRIPTION
When helping Rae setup her Postgres, she was unable to get the `pgstart` alias to be available when opening a new terminal after pasting the alias into her `.bashrc` file. However, it was available when she ran `source .bashrc`. In case other students have that issue, I added in a mention for it.

She also had an error after first installing Postgres and trying to run `psql` where it said, "Cannot find database rahelsel." The issue was solved by running `createdb -U rahelsel`, then running `psql` again. I've added in that additional note to the instructions for Mac users, too.