### PR TITLE
Update to Windows psql install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ If things do not go smoothly, list the errors you received in your Canvas submis
 
 For both Windows and Linux users, please follow the default installation instructions taking care not to change values such as the default port numbers (You may be prompted to change them, but should also be given default values).
 
+
+
+
+
 ### Windows
 
 *For reference, these instructions are taken from the following documentation: http://www.postgresqltutorial.com/install-postgresql/*
@@ -136,18 +140,64 @@ For both Windows and Linux users, please follow the default installation instruc
 
 **Installing**
 
-Double click on the installer file. An installation wizard will appear and guide you through multiple steps where you can choose different options that you would like to have in PostgreSQL. For now, just select default values.
+Double click on the installer file. An installation wizard will appear and guide you through multiple steps where you can choose different options that you would like to have in PostgreSQL. For now, just select default values. Once it's done installing then move to the next step.
+
+At the time of writing, PostgreSQL does not get added to your path by default, so we will need to add it manually, but future versions may fix that. So let's check real quick:
+
+- Open Git Bash and type `psql -U postgres` .
+- If you get a prompt asking for a password then PostgreSQL was installed and added to your PATH. You can skip to the Verify Installation section below.
+
+- If you get and error similar to `bash: psql command not found` then that means you will need to add Postgres to your path. Follow the steps below to do that.
+
+**Adding psql to your PATH**
+
+Normally when programs are installed ( like VScode for Windows) they are automatically added to your PATH which means you can type a quick command to execute the program ( like `code` for VScode for example). Here is how you add the psql command to your PATH which will allow you to launch PostgreSQL in Git Bash.
+
+- Copy this line, `C:\Program Files\PostgreSQL\<version>\bin` and put the version number of PostgeSQL inside of  <version>. IE `C:\Program Files\PostgreSQL\10\bin`.
+- Open your system settings. ( On windows 10 you can right click on the start menu and navigate to settings ).
+
+- You should see a search bar. Type `env` and the search will populate with a couple options. Choose the option that says "Edit the System Enviroment Settings".
+![](https://i.imgur.com/ZT7xvD9.png)
+
+- A small window will pop-up. At the bottomm, directly above the cancel button, is another button that says Enviroment Variables. Click that.
+![](https://i.imgur.com/IjkiSrk.png)
+
+- Another window will pop-up. This is where you can see all of your enviroment variables. Click on the one that says PATH, and then click edit.
+![](https://i.imgur.com/t25DE7n.png)
+
+- Finally, this last page will show you all of the things that are attached to your PATH. If you have installed Node and VS Code you may seem them in here! Click on New and you'll see a text entry box appear in the middle of the page. Paste in the line that you copied from step 1. Hit enter and then make sure to click Okay on all 3 previous boxes!
+![](https://i.imgur.com/1RmmVdh.png)
+ 
+- Close out of all windows, restart your computer, and move to Verify Installation!
+
 
 **Verify Installation**
 
+- Open the Git  Bash terminal and type `psql -U postgres`. It should prompt you for a password. If you get the error `bash: psql command not found`, and you already followed the steps for adding psql to your path then try restarting your computer then going through the above steps again to see if PostgreSQL is still attached to your PATH. If it's not, then and add it again. Restart and try again this step again. **_If it still isn't working, then let the instructor know and skip to the Alternate Verify Installation section.
+
+- If it did work and you were prompted to enter a password then psql has been successfully added to your PATH.  
+- In the password field, enter the password that you gave when you installed PostgreSQL.
+- If it works, then your terminal window will change to the PostgreSQL interface.
+- In this window, you can enter SQL statements, which must end with semicolons. Congratulations,you've installed PostgreSQL correctly!
+
+- Note: If you used a different username then you can specify that after the `-U` in `psql -U <username>`. In most cases, by default the username is postgres, but it may have been changed to the username that you're currently logged into your computer account with. 
+
+**If you are having issues with the installation, please inform your instructor and try the Alternate Verify Installation.**
+
+
+
+**Alternate Verify Installation**
+
 When you installed PostgreSQL, the installer also installed some extra tools. One of them is psql (it may be called SQL Shell).
 
-- Launch psql.
+- Open the SQL shell program.
 - When it prompts you for input, just hit enter to select default values until it asks for a password. You will put in the password you entered during installation.
 - You should have a window that [looks like this](http://www.postgresqltutorial.com/wp-content/uploads/2012/08/psql.png).
 - In this window, you can enter SQL statements, which must all end with semicolons. Congratulations, you've installed correctly!
 
 **If you are having issues with the installation, please contact your instructor.**
+
+
 
 ### Linux
 


### PR DESCRIPTION
Added a step that allows the students to use the command psql with their gitbash terminal instead of having to rely on the postgres shell that comes with the installer. 

1. Add psql to the path.

- The psql command isn't automatically added to the path when postgres is installed, so they have to use the psql shell tool that comes with the installer. This is unnecessary because the same functionality can be achieved through Gitbash.

- Currently, when the students reach week 3 || 6, they will have trouble working with Heroku CLI, heroku pg: * , and their deployed databases because some of the heroku pg:* commands don't work in the psql shell. Some of this can be mitigated by having them add the path in the pre-work, and it will prevent them from having to change their workflow again during this week.

- There will still be some extra steps that the Windows students will have to take during week 3 that can be a bit overwhelming, so adding this into the pre-work can help soften that blow. We can also address any issues with setting their path early on so we and they won't have to worry about it later.