### PR TITLE
Revert using try.jquery.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Note that the tasks below have a corresponding assignment to submit in your Canv
 
 ### jQuery
 
-Complete the official introductory [jQuery Course](https://try.jquery.com). The Canvas submission is a screenshot indicating that the course is complete.
+Complete all of the free portions (not the paid "Pro" ones) [Codecademy course in jQuery](https://www.codecademy.com/en/tracks/jquery). The Canvas submission is a screenshot indicating that the course is complete.
+
+If you would like extra practice on jQuery, [Khan Academy also has a course](https://www.khanacademy.org/computing/computer-programming/html-js-jquery) that you are free to look at and work through, but is not required.
 
 ### Code Wars
 


### PR DESCRIPTION
Reverts codefellows/code-301-prework#31.

[try.jquery.com](http://try.jquery.com) now redirects to jquery.com. Did it formerly redirect to https://www.pluralsight.com/courses/code-school-try-jquery? Is the Code School (Pluralsight) one better enough over Code Academy or Khan Academy to justify folks creating yet another account?